### PR TITLE
Update notebook node prefab for hovering on spells

### DIFF
--- a/Assets/Prefabs/UI/Node.prefab
+++ b/Assets/Prefabs/UI/Node.prefab
@@ -241,6 +241,7 @@ GameObject:
   - component: {fileID: 7505808742388658240}
   - component: {fileID: 7505808742388658243}
   - component: {fileID: 7505808742388658246}
+  - component: {fileID: 5521939385717775060}
   m_Layer: 5
   m_Name: Button
   m_TagString: Untagged
@@ -375,6 +376,35 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &5521939385717775060
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7505808742388658253}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Delegates:
+  - eventID: 0
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 7505808742388658243}
+          m_TargetAssemblyTypeName: NotepadNodeInput, Assembly-CSharp
+          m_MethodName: OnHoverButton
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
 --- !u!1 &7505808742539845046
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Notepad/NotepadLogic.cs
+++ b/Assets/Scripts/Notepad/NotepadLogic.cs
@@ -55,14 +55,15 @@ public class NotepadLogic : Singleton<NotepadLogic>
     }
 
     private void OnInputPress(object sender, int inputNum) {
-        if(!activePattern && inputNum == startNode && !activeLineAnimation) 
+        if(!activePattern && inputNum == startNode && !activeLineAnimation) {
             StartPattern();
-        
-        else if(activePattern && inputNum == endNode)
+        }
+        else if(activePattern && inputNum == endNode) {
             EndPattern();
-
-        else if(activePattern && !pattern.Contains(inputNum))
+        }
+        else if(activePattern && !pattern.Contains(inputNum)) {
             AddToPattern(inputNum);
+        }
         else {
             //invalid input: active node, non-start node on inactive pattern, etc
             //handle at will

--- a/Assets/Scripts/Notepad/NotepadNodeInput.cs
+++ b/Assets/Scripts/Notepad/NotepadNodeInput.cs
@@ -9,4 +9,8 @@ public class NotepadNodeInput : NotepadInput
     public void OnClickButton() {
         base.InvokeInputPress(this, nodeNum);
     }
+
+    public void OnHoverButton() {
+        base.InvokeInputPress(this, nodeNum);
+    }
 }


### PR DESCRIPTION
This updates the notebook node prefab to run a new OnHoverInput callback whenever the mouse goes over the element. This works surprisingly well for how small of a change it is. New behavior in the following video:

https://youtu.be/x2J1CqogIr4