### PR TITLE
General Bugfixes

### DIFF
--- a/Assets/Prefabs/Player/Player.prefab
+++ b/Assets/Prefabs/Player/Player.prefab
@@ -388,7 +388,7 @@ ParticleSystem:
   emitterVelocityMode: 1
   looping: 0
   prewarm: 0
-  playOnAwake: 1
+  playOnAwake: 0
   useUnscaledTime: 0
   autoRandomSeed: 1
   startDelay:
@@ -5335,7 +5335,7 @@ ParticleSystem:
   emitterVelocityMode: 1
   looping: 0
   prewarm: 0
-  playOnAwake: 1
+  playOnAwake: 0
   useUnscaledTime: 0
   autoRandomSeed: 1
   startDelay:
@@ -10205,7 +10205,7 @@ ParticleSystem:
   emitterVelocityMode: 1
   looping: 0
   prewarm: 0
-  playOnAwake: 1
+  playOnAwake: 0
   useUnscaledTime: 0
   autoRandomSeed: 1
   startDelay:
@@ -15129,7 +15129,7 @@ ParticleSystem:
   emitterVelocityMode: 1
   looping: 0
   prewarm: 0
-  playOnAwake: 1
+  playOnAwake: 0
   useUnscaledTime: 0
   autoRandomSeed: 1
   startDelay:

--- a/Assets/Prefabs/Spells/Chair_Spell.prefab
+++ b/Assets/Prefabs/Spells/Chair_Spell.prefab
@@ -115,7 +115,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 3
   m_Sprite: {fileID: 21300000, guid: 989ceff47c7ad7340a7c495f0cbf1165, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
@@ -142,12 +142,12 @@ MonoBehaviour:
   spell: {fileID: 11400000, guid: 0b831836399b0754d9f5861a550b1331, type: 2}
   collider: {fileID: 0}
   rb: {fileID: 1026724369791607120}
-  rotate: {x: 0, y: 0, z: -90}
+  rotate: {x: 0, y: 0, z: 180}
   spellActive: 1
   isChair: 1
   isWind: 0
   isPiplup: 1
-  direction: {x: 1, y: 0}
+  direction: {x: 0, y: -1}
   damage: 0
 --- !u!61 &3702030663533370546
 BoxCollider2D:
@@ -162,7 +162,7 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0.0055760145, y: -0.06130752}
+  m_Offset: {x: 0, y: -0.42}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
@@ -173,7 +173,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 0.7546544, y: 1.4982154}
+  m_Size: {x: 0.75, y: 0.8}
   m_EdgeRadius: 0
 --- !u!114 &5794971183758856041
 MonoBehaviour:

--- a/Assets/Prefabs/Spells/Fireball_Spell.prefab
+++ b/Assets/Prefabs/Spells/Fireball_Spell.prefab
@@ -4916,12 +4916,12 @@ MonoBehaviour:
   spell: {fileID: 11400000, guid: a027ff46ade83dc43aee18da74e625c1, type: 2}
   collider: {fileID: 0}
   rb: {fileID: 7410404838220746693}
-  rotate: {x: 0, y: 0, z: -90}
+  rotate: {x: 0, y: 0, z: 180}
   spellActive: 1
   isChair: 0
   isWind: 0
   isPiplup: 0
-  direction: {x: 1, y: 0}
+  direction: {x: 0, y: -1}
   damage: 5
 --- !u!212 &4974338871379012986
 SpriteRenderer:
@@ -4963,7 +4963,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 3
   m_Sprite: {fileID: 1768438839, guid: a124e1c4efdfeb044948faff1a765f4b, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0

--- a/Assets/Prefabs/Spells/Iceball_Spell.prefab
+++ b/Assets/Prefabs/Spells/Iceball_Spell.prefab
@@ -72,7 +72,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 3
   m_Sprite: {fileID: -844386243, guid: e590480848750a647a959e8fdf86204a, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
@@ -4968,7 +4968,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 3
   m_Sprite: {fileID: -844386243, guid: e590480848750a647a959e8fdf86204a, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
@@ -5054,7 +5054,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 3
   m_Sprite: {fileID: 2029376765, guid: f1a14d2886d392840838df957cb64ecf, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0

--- a/Assets/Prefabs/Spells/Windblast_Spell.prefab
+++ b/Assets/Prefabs/Spells/Windblast_Spell.prefab
@@ -4884,7 +4884,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 3
   m_Sprite: {fileID: 21300000, guid: 07be263fd16fc7f43aec1cf67b590f29, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
@@ -4976,6 +4976,7 @@ MonoBehaviour:
   isWind: 1
   isPiplup: 0
   direction: {x: 0, y: -1}
+  damage: 0
 --- !u!61 &9097417068368567135
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -4989,7 +4990,7 @@ BoxCollider2D:
   m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: -0.0001272913, y: -0.04796879}
+  m_Offset: {x: 0, y: -0.2}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
@@ -5000,7 +5001,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 0.12159225, y: 0.084760934}
+  m_Size: {x: 0.6, y: 0.2}
   m_EdgeRadius: 0
 --- !u!114 &7995059032508458879
 MonoBehaviour:

--- a/Assets/Scripts/Enemy/Enemy.cs
+++ b/Assets/Scripts/Enemy/Enemy.cs
@@ -85,7 +85,7 @@ public class Enemy : MonoBehaviour
             return;
         }
         TakeDamage(meleeDamage);
-        onMeleeHit?.Invoke();
+        if (!isInDarkRoom) onMeleeHit?.Invoke();
         
     }
 

--- a/Assets/Scripts/FakeChestScript.cs
+++ b/Assets/Scripts/FakeChestScript.cs
@@ -49,9 +49,6 @@ public class FakeChestScript : MonoBehaviour
         }
         if (Input.GetKeyDown(_intKey)) {
           StartCoroutine(EnemySpawn());
-          if (_tutInstance != null) {
-            _tutScript.Fade();
-          }
         }
       } else if (_tutInstance) {
         _tutScript.Fade();
@@ -83,10 +80,14 @@ public class FakeChestScript : MonoBehaviour
         AudioControl.Instance.PlaySFX("Chest Open", gameObject);
         yield return new WaitForSeconds(1.0f);
         //spawn enemy
-        GameObject newEnemy = Instantiate(enemy, enemySpawnPoint.position, enemySpawnPoint.rotation);
+        var newEnemy = Instantiate(enemy, enemySpawnPoint.position, enemySpawnPoint.rotation);
         newEnemy.name = newEnemy.name.Replace("(Clone)","").Trim();
-        animator.SetBool("OpeningChest", false);
-        AudioControl.Instance.PlaySFX("Chest Close", gameObject);
-        door.GetComponent<Door>().OpenDoor();
-    }
+        //animator.SetBool("OpeningChest", false);
+        //AudioControl.Instance.PlaySFX("Chest Close", gameObject);
+		if (_tutInstance != null) {
+			_tutScript.Fade();
+			_tutScript.transform.SetParent(transform.parent);
+		} Destroy(this);
+		//door.GetComponent<Door>().OpenDoor();
+	}
 }

--- a/Assets/Scripts/FakeChestScript.cs
+++ b/Assets/Scripts/FakeChestScript.cs
@@ -32,7 +32,7 @@ public class FakeChestScript : MonoBehaviour
         //_player = GameObject.FindGameObjectWithTag("Player").GetComponent<Transform>();
         _virtualCamera = GameObject.Find("Main Camera").transform.Find(virtualCameraName).GetComponent<CinemachineVirtualCamera>();
         _returnToPlayer = _virtualCamera.Follow;
-        StartCoroutine(CameraTransitionIn());
+        if (_cameraTarget != null) StartCoroutine(CameraTransitionIn());
         animator = GetComponent<Animator>();
     }
 

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -125,7 +125,7 @@ public class PlayerController : Singleton<PlayerController>
     }
 
     private void OnTriggerEnter2D(Collider2D other) {
-        if (other.gameObject.CompareTag("EnemyProjectile")) {
+        if (other.gameObject.CompareTag("EnemyProjectile") && canMove) {
             // **FIX**
             //Damage taken when melee on enemy
             TakeDamage(1);

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -131,7 +131,6 @@ public class PlayerController : Singleton<PlayerController>
             TakeDamage(1);
             if (playerHealth <= 0) {
                 playerHealth = 0;
-                GetComponent<Collider2D>().enabled = false;
                 StartCoroutine(Die());
             }
         }
@@ -153,7 +152,6 @@ public class PlayerController : Singleton<PlayerController>
         canMove = true;
         canChangeDir = true;
         dissolveShader.DissolveIn();
-		GetComponent<Collider2D>().enabled = true;
 		transform.position = spawn.transform.position;
         playerHealth = maxHealth;
     }

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -145,13 +145,16 @@ public class PlayerController : Singleton<PlayerController>
     }
 
     IEnumerator Die() {
-        canMove = false;
+		canMove = false;
         canChangeDir = false;
         dissolveShader.DissolveOut();
-        yield return new WaitForSeconds(1.5f);
+		GetComponent<Collider2D>().enabled = false;
+		yield return new WaitForSeconds(1.5f);
+        GetComponent<Collider2D>().enabled = true;
         canMove = true;
         canChangeDir = true;
-        dissolveShader.DissolveIn();
+		ChooseFacingDir();
+		dissolveShader.DissolveIn();
 		transform.position = spawn.transform.position;
         playerHealth = maxHealth;
     }

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -79,11 +79,6 @@ public class PlayerController : Singleton<PlayerController>
             PushTranslate();
         }
         healthText.text = "Health: " + playerHealth;
-        if (spawn.gameObject.tag == "DarkRoom") {
-            sr.material = defaultLit;
-        } else {
-            sr.material = dissolve;
-        }
     }
 
     private void OnMove(InputValue movementValue) {
@@ -149,13 +144,13 @@ public class PlayerController : Singleton<PlayerController>
         canChangeDir = false;
         dissolveShader.DissolveOut();
 		GetComponent<Collider2D>().enabled = false;
-		yield return new WaitForSeconds(1.5f);
-        GetComponent<Collider2D>().enabled = true;
+        yield return new WaitForSeconds(3f);
+		transform.position = spawn.transform.position;
+		dissolveShader.DissolveIn();
+		GetComponent<Collider2D>().enabled = true;
         canMove = true;
         canChangeDir = true;
 		ChooseFacingDir();
-		dissolveShader.DissolveIn();
-		transform.position = spawn.transform.position;
         playerHealth = maxHealth;
     }
 
@@ -181,7 +176,12 @@ public class PlayerController : Singleton<PlayerController>
 
     public void ChangeSpawn(Transform newSpawn) {
         spawn = newSpawn;
-    }
+		if (spawn.gameObject.tag == "DarkRoom") {
+			sr.material = defaultLit;
+		} else {
+			sr.material = dissolve;
+		}
+	}
 
     //adding push behavior for spikes
     public void Push(Vector2 dir, float dist, float spd) {
@@ -205,8 +205,6 @@ public class PlayerController : Singleton<PlayerController>
     public bool GetPushed() {
         return isPushed;
     }
-
-
 }
 
 

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -125,12 +125,13 @@ public class PlayerController : Singleton<PlayerController>
     }
 
     private void OnTriggerEnter2D(Collider2D other) {
-        if (other.gameObject.CompareTag("EnemyProjectile") && canMove) {
+        if (other.gameObject.CompareTag("EnemyProjectile")) {
             // **FIX**
             //Damage taken when melee on enemy
             TakeDamage(1);
             if (playerHealth <= 0) {
                 playerHealth = 0;
+                GetComponent<Collider2D>().enabled = false;
                 StartCoroutine(Die());
             }
         }
@@ -152,7 +153,8 @@ public class PlayerController : Singleton<PlayerController>
         canMove = true;
         canChangeDir = true;
         dissolveShader.DissolveIn();
-        transform.position = spawn.transform.position;
+		GetComponent<Collider2D>().enabled = true;
+		transform.position = spawn.transform.position;
         playerHealth = maxHealth;
     }
 

--- a/Assets/Scripts/Puzzles/Firewood_Script.cs
+++ b/Assets/Scripts/Puzzles/Firewood_Script.cs
@@ -89,6 +89,8 @@ public class Firewood_Script : MonoBehaviour
                 return;
             }
             prevLitStatus = 0;
+        } else {
+            return;
         }
         //if (!checkIfRepeat) {
             if (adjFirewood1 != null) {

--- a/Assets/Scripts/Puzzles/LabReport.cs
+++ b/Assets/Scripts/Puzzles/LabReport.cs
@@ -125,22 +125,35 @@ public class LabReport : MonoBehaviour
 				} break;
 
 			case State.Writing:
-				if (textTimer <= 0 && currentText != null) {
-					// Move the start of the invisible color tag toward the end, thus showing more characters;
-					if (currentIndex < string2Report.Length && string2Report[currentIndex] != '\\') {
-						AudioControl.Instance.PlayVoidSFX(soundStrings[UnityEngine.Random.Range(0,2)], 0.15f);
-						currentText.text = BuildStr(string2Report, "|");
-						textTimer = letterWait;
-						currentIndex++;
-					} else if (currentIndex < string2Report.Length && string2Report[currentIndex] == '\\') {
+				if (currentText != null) {
+					if (textTimer <= 0) {
+						// Move the start of the invisible color tag toward the end, thus showing more characters;
+						if (currentIndex < string2Report.Length && string2Report[currentIndex] != '\\') {
+							AudioControl.Instance.PlayVoidSFX(soundStrings[UnityEngine.Random.Range(0, 2)], 0.15f);
+							currentText.text = BuildStr(string2Report, "|");
+							textTimer = letterWait;
+							currentIndex++;
+						}
+						else if (currentIndex < string2Report.Length && string2Report[currentIndex] == '\\') {
+							state = State.Waiting;
+							currentText.text = BuildStr(string2Report, "|");
+							textTimer = 0;
+						}
+						else if (currentIndex == string2Report.Length) {
+							state = State.Waiting;
+							textTimer = 0;
+						}
+					}
+					if (Input.GetKeyDown(intKey)) {
 						state = State.Waiting;
-						currentText.text = BuildStr(string2Report, "|");
-						textTimer = 0;
-					} else if (currentIndex == string2Report.Length) {
-						state = State.Waiting;
+						AudioControl.Instance.PlayVoidSFX(soundStrings[UnityEngine.Random.Range(0, 2)], 0.2f);
+						currentText.text = BuildStr(string2Report, "<color=#00000000>|</color>");
+						currentIndex = string2Report.Length;
+						waitForPress = true;
 						textTimer = 0;
 					}
-				} break;
+				}
+				break;
 
 			case State.Waiting:
 				if (currentText != null) {
@@ -199,16 +212,6 @@ public class LabReport : MonoBehaviour
 						}
 					}
 				} break;
-		}
-
-		// Finish earlier if player presses skip button;
-		if (state == State.Writing && Input.GetKeyDown(intKey) && currentText != null) {
-			state = State.Waiting;
-			AudioControl.Instance.PlayVoidSFX(soundStrings[UnityEngine.Random.Range(0, 2)], 0.2f);
-			currentText.text = BuildStr(string2Report, "<color=#00000000>|</color>");
-			currentIndex = string2Report.Length;
-			waitForPress = true;
-			textTimer = 0;
 		}
 
 		// Fading effect of the pop-up;

--- a/Assets/Scripts/Puzzles/LabReport.cs
+++ b/Assets/Scripts/Puzzles/LabReport.cs
@@ -18,9 +18,8 @@ public class LabReport : MonoBehaviour
 	private List<string> strings2Grab;			// List of strings that will be taken from the ScriptableObject;
 	private string string2Report;				// String that will be grabbed based on the reportNumber;
 
-	private string intKey = "z";				// Key used to trigger the interactions;
-	private string spdKey = "x";				// Key used to speed up the text;
-	private string skpKey = "c";				// Key used to skip the writing cinematic;
+	private string intKey = "space";				// Key used to trigger interactions;
+	private bool waitForPress = false;				// Lazy boolean, zero creativity atm ;-;
 
 	// References;
 	private PlayerController playerController;
@@ -40,14 +39,12 @@ public class LabReport : MonoBehaviour
 	} private State state = State.Idle;
 
 	private float textTimer = 0;
-	private float noteTimer = 0;
 
 	private TextMeshProUGUI currentText; // Reference to the text instance operating;
 	private TextMeshProUGUI currentNote; // Reference to the bottom note pointing the key to press;
 
 	// Text pacing variables
 	private float letterWait = 0.05f;  // Controls how fast are characters written to the screen;
-	private float normalWait = 0.05f;  // Delay if no button is pressed;
 	private int currentIndex;          // Controls the current limit of the written string;
 	private bool dotted = false;       // Variable to control the cursor;
 
@@ -131,7 +128,7 @@ public class LabReport : MonoBehaviour
 				if (textTimer <= 0 && currentText != null) {
 					// Move the start of the invisible color tag toward the end, thus showing more characters;
 					if (currentIndex < string2Report.Length && string2Report[currentIndex] != '\\') {
-						if (letterWait > 0) AudioControl.Instance.PlayVoidSFX(soundStrings[UnityEngine.Random.Range(0,2)], 0.15f);
+						AudioControl.Instance.PlayVoidSFX(soundStrings[UnityEngine.Random.Range(0,2)], 0.15f);
 						currentText.text = BuildStr(string2Report, "|");
 						textTimer = letterWait;
 						currentIndex++;
@@ -143,13 +140,6 @@ public class LabReport : MonoBehaviour
 						state = State.Waiting;
 						textTimer = 0;
 					}
-				}
-				// Speed up the writing process if the speed key is pressed;
-				if (Input.GetKey(spdKey)) {
-					textTimer = 0;
-					letterWait = 0;
-				} else {
-					letterWait = normalWait;
 				} break;
 
 			case State.Waiting:
@@ -167,27 +157,29 @@ public class LabReport : MonoBehaviour
 						}
 					}
 					// Continue writing or finish report if an input key is pressed;
-					if (Input.GetKey(intKey) || Input.GetKey(spdKey)) {
+					if (Input.GetKeyUp(intKey)) {
 						if (currentIndex < string2Report.Length) {
 							state = State.Writing;
 							string2Report = string2Report.Substring(0, currentIndex) + "<color=#00000000>|</color>"
 											 + string2Report.Substring(currentIndex);
 							currentIndex += 31; // Skip length of tag + length of escape sequence;
-							textTimer = 0;
-						} else if (Input.GetKeyDown(intKey) || Input.GetKeyDown(spdKey)) {
+						} else if (!waitForPress) {
 							state = State.End;
+						} else {
+							waitForPress = false;
 						}
+						textTimer = 0;
 					}
 				} break;
 
 			case State.End:
 				if (currentText != null) {
 					// Finish report if there are no more pages to present;
-					if (strings2Grab.Count <= 0) transitionScript.DarkenIn();
+					if (strings2Grab.Count == 0) transitionScript.DarkenIn();
 					// Fade out all text;
-					textAlpha -= 5;
+					textAlpha = (byte) Mathf.Max(0, (int) textAlpha - 10);
 					currentText.color = new Color32(_r, _g, _b, textAlpha);
-					if (noteAlpha >= 5) { noteAlpha -= 5; };
+					if (noteAlpha >= 5) { noteAlpha = (byte) Mathf.Max(0, (int) textAlpha - 10); };
 					currentNote.color = new Color32(_r, _g, _b, noteAlpha);
 					// Continue to next page if there's one or finalize report;
 					if (textAlpha < 5) {
@@ -210,10 +202,12 @@ public class LabReport : MonoBehaviour
 		}
 
 		// Finish earlier if player presses skip button;
-		if (ReportIsActive() && Input.GetKeyDown(skpKey) && currentText != null) {
+		if (state == State.Writing && Input.GetKeyDown(intKey) && currentText != null) {
 			state = State.Waiting;
+			AudioControl.Instance.PlayVoidSFX(soundStrings[UnityEngine.Random.Range(0, 2)], 0.2f);
 			currentText.text = BuildStr(string2Report, "<color=#00000000>|</color>");
 			currentIndex = string2Report.Length;
+			waitForPress = true;
 			textTimer = 0;
 		}
 
@@ -224,21 +218,15 @@ public class LabReport : MonoBehaviour
 			} else if (noteAlpha <= 50) {
 				alertUp = true;
 			}
-			if (noteTimer <= 0) {
-				if (alertUp) {
-					noteAlpha++;
-					noteTimer = 0.002f;
-				}
-				else {
-					noteAlpha--;
-					noteTimer = 0.002f;
-				}
+			if (alertUp) {
+				noteAlpha++;
+			} else {
+				noteAlpha--;
 			}
 			currentNote.color = new Color32(_r, _g, _b, noteAlpha);
 		}
 
 		if (textTimer > 0) textTimer -= Time.deltaTime;
-		if (noteTimer > 0) noteTimer -= Time.deltaTime;
 	}
 	
 	// Instantiates the text and the button/bottom note \\
@@ -262,7 +250,7 @@ public class LabReport : MonoBehaviour
 			bottomNoteTransform.rotation = canvasTransform.rotation;
 			bottomNoteTransform.position = new Vector3(canvasTransform.position.x, canvasTransform.position.y - 7, canvasTransform.position.z);
 			currentNote = bottomNote.GetComponent<TextMeshProUGUI>();
-			currentNote.text = "Speed [" + spdKey.ToUpper() + "]        Advance [" + intKey.ToUpper() + "]        Skip [" + skpKey.ToUpper() + "]";
+			currentNote.text = "Advance [" + intKey.ToUpper() + "]";
 		}
 	}
 

--- a/Assets/Scripts/UI/PauseMenu.cs
+++ b/Assets/Scripts/UI/PauseMenu.cs
@@ -28,7 +28,8 @@ public class PauseMenu : MonoBehaviour
     public void Resume()
     {
         pauseMenuUI.SetActive(false);
-        Time.timeScale = 1f;
+		PlayerController.Instance.ActivateMovement();
+		Time.timeScale = 1f;
         GameIsPaused = false;
     }
 
@@ -36,6 +37,7 @@ public class PauseMenu : MonoBehaviour
     void Pause()
     {
         pauseMenuUI.SetActive(true);
+        PlayerController.Instance.DeactivateMovement();
         Time.timeScale = 0f;
         GameIsPaused = true;
     }

--- a/Assets/Scripts/Unused/Jung/RoomControlA3.cs
+++ b/Assets/Scripts/Unused/Jung/RoomControlA3.cs
@@ -11,7 +11,6 @@ public class RoomControlA3 : MonoBehaviour
     
     public GameObject B3Chest = null;
     public bool cheat = false;
-    public bool _earlyRoom = false;
 
     public string virtualCameraName = "CM vcam1";	// For security reasons, the name of the virtual camera can be modified here if changed in the scene.
 	private CinemachineVirtualCamera _virtualCamera;
@@ -30,32 +29,14 @@ public class RoomControlA3 : MonoBehaviour
 
     void Update() {
         if (!isClear) {
+            _canClear = true;
             foreach (PressurePlate_Script plate in _pressurePlates) {
                 if (!plate.GetIsPressed()) {
                     _canClear = false;
                     break; 
                 }
             }
-
-			if (_canClear) {
-                if (_earlyRoom) {
-                    StartCoroutine(CameraTransitionIn());
-                    StartCoroutine(DoorOpen());
-                    _earlyRoom = false;
-                    return;
-                }
-				B3Chest.SetActive(true);
-				StartCoroutine(DurationTime());
-				isClear = true;
-				//Destroy(this.gameObject);
-			}
-			_canClear = true;
-
-			if (cheat) {
-                B3Chest.SetActive(true);
-                isClear = true;
-                //Destroy(this.gameObject);
-            }
+            if (_canClear) CompleteRoom();
         }
     }
 
@@ -71,10 +52,12 @@ public class RoomControlA3 : MonoBehaviour
         _virtualCamera.Follow = _returnToPlayer;
 	}
 
-    IEnumerator DoorOpen() {
-        yield return new WaitForSeconds(0.0f);
-        door.GetComponent<Door>().OpenDoor();
-    }
-
-
+	private void CompleteRoom() {
+		if (!cheat) {
+			StartCoroutine(CameraTransitionIn());
+			door.GetComponent<Door>().OpenDoor();
+		}
+        if (B3Chest) B3Chest.SetActive(true);
+		isClear = true;
+	}
 }

--- a/Assets/Scripts/Unused/RoomControlA2.cs
+++ b/Assets/Scripts/Unused/RoomControlA2.cs
@@ -31,49 +31,32 @@ public class RoomControlA2 : MonoBehaviour
     // Update is called once per frame
     void Update() {
         if (!isClear) {
+            _canClear = true;
             foreach (Firewood_Script _firewood in _firewoods) {
                 if (!_firewood.isLit) { _canClear = false; break; }
             }
-
-			if (_canClear) {
-                if (_earlyRoom) {
-                    StartCoroutine(CameraTransitionIn());
-                    StartCoroutine(DoorOpen());
-                    _earlyRoom = false;
-                    return;
-                }
-				A2Chest.SetActive(true);
-				//spellNotif.SetActive(true);
-				StartCoroutine(DurationTime());
-				isClear = true;
-				Destroy(this.gameObject);
-			}
-			_canClear = true;
-
-			if (cheat) {
-                A2Chest.SetActive(true);
-                //spellNotif.SetActive(true);
-                //StartCoroutine(DurationTime());
-                isClear = true;
-                Destroy(this.gameObject);
-            }
+            if (_canClear) CompleteRoom();
         }
     }
 
-	IEnumerator DurationTime() {
-		yield return new WaitForSeconds(5f);
-		//spellNotif.SetActive(false);
-	}
-
     IEnumerator CameraTransitionIn() {
-		yield return new WaitForSeconds(0.0f);
+        yield return new WaitForSeconds(0.0f);
 		_virtualCamera.Follow = _cameraTarget.transform;
 		yield return new WaitForSeconds(2f);
         _virtualCamera.Follow = _returnToPlayer;
+		Destroy(this.gameObject);
+		//spellNotif.SetActive(false);
 	}
 
-    IEnumerator DoorOpen() {
-        yield return new WaitForSeconds(0.0f);
-        door.GetComponent<Door>().OpenDoor();
-    }
+	private void CompleteRoom() {
+        if (!cheat) {
+            StartCoroutine(CameraTransitionIn());
+			door.GetComponent<Door>().OpenDoor();
+            if (!_earlyRoom) A2Chest.SetActive(true);
+        } else {
+			if (!_earlyRoom) A2Chest.SetActive(true);
+			Destroy(this.gameObject);
+		}
+		isClear = true;
+	}
 }

--- a/Assets/Scripts/Utility/PressurePlate_Script.cs
+++ b/Assets/Scripts/Utility/PressurePlate_Script.cs
@@ -55,6 +55,9 @@ public class PressurePlate_Script : MonoBehaviour
     }
 
     void OnTriggerExit2D(Collider2D other) {
+		if (other && other.tag == "Spell") {
+            return;
+        }
         numObject--; 
         if (numObject == 0) {
             isPressed = false;


### PR DESCRIPTION
- Fixed the firewoods interacting with spells other than Fireball and Iceball.
- Fixed an issue where the Pressure Plates could be exploited by casting a spell inside the collider.
- Fixed a small issue that prevented Grace's dissolve routine from playing on player death.
- Fixed the player being able to change direction in the pause menu, and the melee attack after hitting Resume.
- Fixed the collider of the Windblast Spell being incorrect (too small).
- Fixed the exploit that allowed players to go out of bounds by spawning chairs.
- Panic not. The Lab Report has been reworked to ONLY USE SPACE. 10/10 GOTY.
- Attempted to fix the issue where the lab report text would take too long to fade.
- Adjusted the layering order of spells for visual fidelity. They now spawn behind the player when they are further back, and in front of the player when they are in front of them.
- Fixed a few visual bugs when the player respawns by toggling the player collider and adding a method call.
- Fixed the runtime errors associated with RoomControlA2.cs and RoomControlB3.cs.
- Fixed a few runtime errors associated with the Fake Chest, and the bug that allows to spawn infinite enemies. My approach was to leave the chest in the "Open" state, and kill both the script and the button pop-up. Lmk if you have a different idea in mind.
- Fixed a runtime error associated with a missing Unity Event for Goombas in the Dark Room. Note that they are still missing the knockback feature (that might require making a custom event).
- Fixed the casting particles emitting immediately after the Main room is loaded.