### PR TITLE
Bugfixes

### DIFF
--- a/Assets/Prefabs/Main Menu/AudioManager.prefab
+++ b/Assets/Prefabs/Main Menu/AudioManager.prefab
@@ -183,9 +183,9 @@ MonoBehaviour:
   - name: Main
     clip: {fileID: 8300000, guid: 8196983bb7a99dc47a3e17e77a606386, type: 3}
   - name: Exploration
-    clip: {fileID: 8300000, guid: bf5c5de18f87b5b4aaec6b81397ec2b0, type: 3}
+    clip: {fileID: 8300000, guid: 6789b5ae61f9ca649a587095105f1057, type: 3}
   - name: Combat
-    clip: {fileID: 8300000, guid: ba76bea4b395fee4886f53ba50b9a316, type: 3}
+    clip: {fileID: 8300000, guid: 3779b94063137ad48839e686461581b1, type: 3}
   - name: Exploration Opening
     clip: {fileID: 8300000, guid: 21f1c5187ba79864d9f16f0520e227d2, type: 3}
   - name: EndingPart1

--- a/Assets/Scripts/Audio/AudioControl.cs
+++ b/Assets/Scripts/Audio/AudioControl.cs
@@ -16,6 +16,7 @@ public class AudioControl : Singleton<AudioControl> {
 	[SerializeField] private float maxSFXDistance = 20;
 
 	private const string NULL_CLIP_TEXT = "Invalid clip string passed";
+	private readonly float volumeChangeRate = 0.01f;
 
 	// Employs Travis and Chase's method;                                    
 	void Awake() {
@@ -66,6 +67,7 @@ public class AudioControl : Singleton<AudioControl> {
 		AudioClip clip = FetchClip(name, musicSounds);
 		mainMusicSource.clip = clip;
 		mainMusicSource.Play();
+		Debug.Log(mainMusicSource.clip);
 		return mainMusicSource;
 	}
 
@@ -164,7 +166,7 @@ public class AudioControl : Singleton<AudioControl> {
 		while (lerp > 0) {
 			mainMusicSource.volume = musicVolume * lerp;
 			secondaryMusicSource.volume = musicVolume * (1 - lerp);
-			lerp = Mathf.MoveTowards(lerp, 0, Time.unscaledDeltaTime);
+			lerp = Mathf.MoveTowards(lerp, 0, volumeChangeRate);
 			yield return null;
 		} SwapPrimaryMusicSource();
     }
@@ -185,7 +187,7 @@ public class AudioControl : Singleton<AudioControl> {
 	// Coroutine to fade away the music. Hopefully more efficient than running a bool in Update;
 	IEnumerator _FadeMusic(bool stopsMusic) {
 		while (mainMusicSource.volume > 0) {
-			mainMusicSource.volume = Mathf.Max(0, mainMusicSource.volume - musicVolume / (0.5f / Time.deltaTime));
+			mainMusicSource.volume = Mathf.MoveTowards(mainMusicSource.volume, 0, volumeChangeRate);
 			yield return null;
 		}
 		if (stopsMusic) {
@@ -197,14 +199,18 @@ public class AudioControl : Singleton<AudioControl> {
 	IEnumerator _ResumeMusic() {
 		if (mainMusicSource) mainMusicSource.UnPause();
 		while (mainMusicSource.volume < musicVolume) {
-			mainMusicSource.volume = Mathf.Min(musicVolume, mainMusicSource.volume + musicVolume / (0.5f / Time.deltaTime));
+			mainMusicSource.volume = Mathf.MoveTowards(mainMusicSource.volume, musicVolume, volumeChangeRate);
 			yield return null;
 		}
 	}
 
 	IEnumerator LoadMusic() {
+		Debug.Log("BeganPlaying");
 		var musicSource = PlayMusic("Exploration Opening", false);
-		while (musicSource.isPlaying) yield return null;
+		while (musicSource.isPlaying) {
+			Debug.LogWarning("Loop running");
+			yield return null;
+		} Debug.Log("Music Begins");
 		PlayMusic("Exploration");
 	}
 

--- a/Assets/Scripts/Enemy/Enemy.cs
+++ b/Assets/Scripts/Enemy/Enemy.cs
@@ -41,11 +41,7 @@ public class Enemy : MonoBehaviour, IDamageable, IPushable
 
     public EnemyState currState;
 
-    /// <summary>
-    /// Awake is called when the script instance is being loaded.
-    /// </summary>
-    private void Awake()
-    {
+    private void Start() {
         OnPlayerInRange += BattleManager.Instance.RegisterEnemy;
 
         currHealth = maxHealth;
@@ -53,9 +49,7 @@ public class Enemy : MonoBehaviour, IDamageable, IPushable
         animator = GetComponent<Animator>();
         dealthShader = GetComponent<DealthDissolveShader>();
         sr = GetComponent<SpriteRenderer>();
-    }
 
-    private void Start() {
         healthBar.GetComponent<EnemyHealthBar>().SetUp((int) maxHealth, (int) currHealth);
     }
 

--- a/Assets/Scripts/Main Menu/tranMode.cs
+++ b/Assets/Scripts/Main Menu/tranMode.cs
@@ -18,9 +18,9 @@ public class tranMode : MonoBehaviour {
 	private float target;
 	private CanvasGroup fadeScreen;
 
-	void Start() {
-		AudioControl.Instance.CheckMusic();
+    void Start() {
 		fadeScreen = GetComponentInChildren<CanvasGroup>();
+		AudioControl.Instance.CheckMusic();
 		alpha = 1f;
 		target = 0;
 		currentTransitionTime = longTransitionTime;
@@ -28,7 +28,7 @@ public class tranMode : MonoBehaviour {
 
 	void Update() {
 		if (alpha != target) {
-			alpha = Mathf.MoveTowards(alpha, target, Time.unscaledDeltaTime * 1f/currentTransitionTime);
+			alpha = Mathf.MoveTowards(alpha, target, Mathf.Min(0.025f, Time.unscaledDeltaTime) * 1f/currentTransitionTime);
 			fadeScreen.alpha = alpha;
 		} else if (target == 0) {
 			fadeScreen.blocksRaycasts = false;

--- a/Assets/Scripts/UI/Notification UI/NotificationObject.cs
+++ b/Assets/Scripts/UI/Notification UI/NotificationObject.cs
@@ -16,7 +16,7 @@ public class NotificationObject : MonoBehaviour {
 
     private TextMeshProUGUI text;
 
-    private float duration = 1f;
+    private float duration = 0.75f;
     private float imageWidth;
 	private float maxScale;
     private float timer;
@@ -27,15 +27,15 @@ public class NotificationObject : MonoBehaviour {
 
     public void Initialize(TextMeshProUGUI notificationText, float scaleConstraint) {
         if (text == null) text = notificationText;
-        timer = duration;
         transform.localScale = new Vector3(0, transform.localScale.y, transform.localScale.z);
         text.color = new Color(1, 1, 1, 0);
         text.ForceMeshUpdate(true);
         maxScale = (text.preferredWidth + 16) / imageWidth;
         if (maxScale > scaleConstraint) {
             text.fontSize *= scaleConstraint / maxScale;
-            maxScale = scaleConstraint;
+            maxScale = scaleConstraint + 0.1f;
         } state = State.Start;
+        timer = duration * scaleConstraint;
     }
 
     void Update() {
@@ -43,28 +43,28 @@ public class NotificationObject : MonoBehaviour {
 			case State.Start:
                 if (transform.localScale.x < maxScale) {
                     transform.localScale = Vector3.MoveTowards(transform.localScale,
-                                                           new Vector3(maxScale, transform.localScale.y, transform.localScale.z), 0.05f);
+                                                           new Vector3(maxScale, transform.localScale.y, transform.localScale.z), Time.unscaledDeltaTime * 7.5f);
                 } else {
                     state = State.Write;
                 } break;
             case State.Write:
-                if (text.color.a < 1) {
-                    text.color = Vector4.MoveTowards(text.color, new Color(1, 1, 1, 1), Time.deltaTime * 3f);
+                if (!Mathf.Approximately(text.color.a, 1)) {
+                    text.color = Vector4.MoveTowards(text.color, new Color(1, 1, 1, 1), Time.unscaledDeltaTime * 3f);
                 } else {
                     state = State.Wait;
                 } break;
             case State.Wait:
                 if (timer > 0) {
-                    timer -= Time.deltaTime;
+                    timer -= Time.unscaledDeltaTime;
                 } else {
                     state = State.End;
                 } break;
             case State.End:
-                if (text.color.a > 0) {
-                    text.color = Vector4.MoveTowards(text.color, new Color(1, 1, 1, 0), Time.deltaTime * 3f);
+                if (!Mathf.Approximately(text.color.a, 0)) {
+                    text.color = Vector4.MoveTowards(text.color, new Color(1, 1, 1, 0), Time.unscaledDeltaTime * 3f);
                 } else {
                     transform.localScale = Vector3.MoveTowards(transform.localScale,
-                                                           new Vector3(0, transform.localScale.y, transform.localScale.z), 0.2f);
+                                                               new Vector3(0, transform.localScale.y, transform.localScale.z), Time.unscaledDeltaTime * 10f);
                 }
                 if (transform.localScale.x <= 0) {
                     OnNotificationFinished?.Invoke();


### PR DESCRIPTION
- AudioManager volume doesn't rely on Time.deltaTime anymore (even though this is apparently ok, but just in case);
- AudioManager Prefab saved! Wahoo!
- Enemy.cs doesn't error in build anymore. It was calling for BattleManager.cs before it was initialized, my bad :3
- Loading transitions don't happen over a single frame anymore! Mathf.Min() go brrrrrr >.<
- Some fixes and changes for the notification manager, including some cheap dynamic duration based on the length of the message displayed, some floating point errors that prevented the frame from despawning, and some buffer room in the frame width for elegancy :D

Back to study Physics now ;-;