### PR TITLE
Bugfixes + Disable Timeline + Restore Freeze Sprites

### DIFF
--- a/Assets/Prefabs/CopyObjects/Bookshelf.prefab
+++ b/Assets/Prefabs/CopyObjects/Bookshelf.prefab
@@ -88,6 +88,7 @@ MonoBehaviour:
   shineSpeed: 3.5
   shineWaitRange: {x: 6, y: 8}
   freezeMaterial: {fileID: 2100000, guid: 9eab87c4428710a4dbb58454862a67b3, type: 2}
+  alternateSprite: {fileID: 21300000, guid: a64e8046cd33d3f4cbb0ce90016293d0, type: 3}
 --- !u!114 &1879717614967529872
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -101,6 +102,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   dust: {fileID: 1006737300058186955}
+  pushMultiplier: 1
 --- !u!212 &5314903090662639377
 SpriteRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/CopyObjects/Bush.prefab
+++ b/Assets/Prefabs/CopyObjects/Bush.prefab
@@ -88,6 +88,7 @@ MonoBehaviour:
   shineSpeed: 3.5
   shineWaitRange: {x: 6, y: 8}
   freezeMaterial: {fileID: 2100000, guid: 9eab87c4428710a4dbb58454862a67b3, type: 2}
+  alternateSprite: {fileID: 21300000, guid: bdc992072bcfec84eb3f9623106a01af, type: 3}
 --- !u!114 &4137070751988683371
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/CopyObjects/CardboardBox.prefab
+++ b/Assets/Prefabs/CopyObjects/CardboardBox.prefab
@@ -88,6 +88,7 @@ MonoBehaviour:
   shineSpeed: 3.5
   shineWaitRange: {x: 6, y: 8}
   freezeMaterial: {fileID: 2100000, guid: 9eab87c4428710a4dbb58454862a67b3, type: 2}
+  alternateSprite: {fileID: 21300000, guid: 309e8e4c89ece324bb1114e64a34c33d, type: 3}
 --- !u!114 &6265735411727060476
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -101,6 +102,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   dust: {fileID: 7238717874534984791}
+  pushMultiplier: 1
 --- !u!212 &2886184989351054560
 SpriteRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/CopyObjects/ComputerDesk.prefab
+++ b/Assets/Prefabs/CopyObjects/ComputerDesk.prefab
@@ -117,6 +117,7 @@ MonoBehaviour:
   shineSpeed: 3.5
   shineWaitRange: {x: 6, y: 8}
   freezeMaterial: {fileID: 2100000, guid: 9eab87c4428710a4dbb58454862a67b3, type: 2}
+  alternateSprite: {fileID: 21300000, guid: 96e7350cff0822a43a761f135de0158e, type: 3}
 --- !u!114 &2285584211662863295
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/CopyObjects/Desk.prefab
+++ b/Assets/Prefabs/CopyObjects/Desk.prefab
@@ -93,6 +93,7 @@ MonoBehaviour:
   shineSpeed: 3.5
   shineWaitRange: {x: 6, y: 8}
   freezeMaterial: {fileID: 2100000, guid: 9eab87c4428710a4dbb58454862a67b3, type: 2}
+  alternateSprite: {fileID: 21300000, guid: 3a549339231035c43804898f1d5f0108, type: 3}
 --- !u!212 &6501937713015008925
 SpriteRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/CopyObjects/Drawer.prefab
+++ b/Assets/Prefabs/CopyObjects/Drawer.prefab
@@ -88,6 +88,7 @@ MonoBehaviour:
   shineSpeed: 3.5
   shineWaitRange: {x: 6, y: 8}
   freezeMaterial: {fileID: 2100000, guid: 9eab87c4428710a4dbb58454862a67b3, type: 2}
+  alternateSprite: {fileID: 21300000, guid: b4de57e3186550e4fadf4bbc91565942, type: 3}
 --- !u!114 &5349781216426889842
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -101,6 +102,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   dust: {fileID: 2675858143119244974}
+  pushMultiplier: 1
 --- !u!212 &8341300847819756202
 SpriteRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/CopyObjects/MirrorObelisk.prefab
+++ b/Assets/Prefabs/CopyObjects/MirrorObelisk.prefab
@@ -51,7 +51,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   attributes:
-    isHeavy: 0
+    isHeavy: 1
     isCopyable: 0
   defaultState: 0
 --- !u!114 &8899674046016632883
@@ -71,6 +71,7 @@ MonoBehaviour:
   shineSpeed: 3.5
   shineWaitRange: {x: 6, y: 8}
   freezeMaterial: {fileID: 2100000, guid: 9eab87c4428710a4dbb58454862a67b3, type: 2}
+  alternateSprite: {fileID: 21300000, guid: e902128f4092cd441b8a50587ca6558c, type: 3}
 --- !u!114 &2656265587042397633
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/CopyObjects/Tank.prefab
+++ b/Assets/Prefabs/CopyObjects/Tank.prefab
@@ -88,6 +88,7 @@ MonoBehaviour:
   shineSpeed: 3.5
   shineWaitRange: {x: 6, y: 8}
   freezeMaterial: {fileID: 2100000, guid: 9eab87c4428710a4dbb58454862a67b3, type: 2}
+  alternateSprite: {fileID: 21300000, guid: a6a9d328e3e75cc46a8b5d0bba7b2c6c, type: 3}
 --- !u!114 &1157913302458378134
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -101,6 +102,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   dust: {fileID: 1113357962131686508}
+  pushMultiplier: 1
 --- !u!212 &8833644641803840437
 SpriteRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/CopyObjects/TankCracked.prefab
+++ b/Assets/Prefabs/CopyObjects/TankCracked.prefab
@@ -88,6 +88,7 @@ MonoBehaviour:
   shineSpeed: 3.5
   shineWaitRange: {x: 6, y: 8}
   freezeMaterial: {fileID: 2100000, guid: 9eab87c4428710a4dbb58454862a67b3, type: 2}
+  alternateSprite: {fileID: 21300000, guid: f7f85e9e491027b4382ea5ca5befb16f, type: 3}
 --- !u!114 &2853237103911139628
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -101,6 +102,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   dust: {fileID: 8369708450241502156}
+  pushMultiplier: 1
 --- !u!212 &4609730501574303362
 SpriteRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/CopyObjects/TankMonster.prefab
+++ b/Assets/Prefabs/CopyObjects/TankMonster.prefab
@@ -88,6 +88,7 @@ MonoBehaviour:
   shineSpeed: 3.5
   shineWaitRange: {x: 6, y: 8}
   freezeMaterial: {fileID: 2100000, guid: 9eab87c4428710a4dbb58454862a67b3, type: 2}
+  alternateSprite: {fileID: 21300000, guid: 217bed7c5e10edc4bb19d33400fa0b3a, type: 3}
 --- !u!114 &8312764789070482206
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -101,6 +102,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   dust: {fileID: 2937377277580454330}
+  pushMultiplier: 1
 --- !u!212 &5667109648531998369
 SpriteRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/CopyObjects/TreeGreen.prefab
+++ b/Assets/Prefabs/CopyObjects/TreeGreen.prefab
@@ -91,6 +91,7 @@ MonoBehaviour:
   shineSpeed: 3.5
   shineWaitRange: {x: 6, y: 8}
   freezeMaterial: {fileID: 2100000, guid: 9eab87c4428710a4dbb58454862a67b3, type: 2}
+  alternateSprite: {fileID: 21300000, guid: 0ada9c8b38dd2744ea836b5fbf674b68, type: 3}
 --- !u!212 &6543267383375713426
 SpriteRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/CopyObjects/TreeOrange.prefab
+++ b/Assets/Prefabs/CopyObjects/TreeOrange.prefab
@@ -91,6 +91,7 @@ MonoBehaviour:
   shineSpeed: 3.5
   shineWaitRange: {x: 6, y: 8}
   freezeMaterial: {fileID: 2100000, guid: 9eab87c4428710a4dbb58454862a67b3, type: 2}
+  alternateSprite: {fileID: 21300000, guid: 0ada9c8b38dd2744ea836b5fbf674b68, type: 3}
 --- !u!212 &3002668612731995711
 SpriteRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Puzzles/Mirror.prefab
+++ b/Assets/Prefabs/Puzzles/Mirror.prefab
@@ -51,7 +51,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   attributes:
-    isHeavy: 0
+    isHeavy: 1
     isCopyable: 0
   defaultState: 0
 --- !u!114 &8696059702228883687

--- a/Assets/Prefabs/Scientist.prefab
+++ b/Assets/Prefabs/Scientist.prefab
@@ -9,9 +9,10 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3540596825122561885}
+  - component: {fileID: 313230819767971587}
+  - component: {fileID: 827608582892340332}
   - component: {fileID: 3540596825122561884}
   - component: {fileID: 3540596825122561887}
-  - component: {fileID: 313230819767971587}
   - component: {fileID: 2580548336516971343}
   - component: {fileID: 4359817717055833088}
   m_Layer: 0
@@ -37,6 +38,40 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &313230819767971587
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3540596825122561886}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d7069dbfdc90ba04ca2e925633ba8033, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  attributes:
+    isHeavy: 0
+    isCopyable: 0
+  defaultState: 0
+--- !u!114 &827608582892340332
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3540596825122561886}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 93c19b0edd5e2924d82ba0ed3b8b77be, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  spriteRenderer: {fileID: 3540596825122561884}
+  freezeSpeed: 2.5
+  shineSpeed: 3.5
+  shineWaitRange: {x: 6, y: 8}
+  freezeMaterial: {fileID: 2100000, guid: 9eab87c4428710a4dbb58454862a67b3, type: 2}
+  alternateSprite: {fileID: 21300000, guid: a1a14991110d8d44ea33caf41cacff70, type: 3}
 --- !u!212 &3540596825122561884
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -115,23 +150,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 2.035553, y: 0.6549568}
   m_EdgeRadius: 0
---- !u!114 &313230819767971587
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3540596825122561886}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d7069dbfdc90ba04ca2e925633ba8033, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  isHeavy: 0
-  onFireSprite: {fileID: 0}
-  onFreezedSprite: {fileID: 21300000, guid: a1a14991110d8d44ea33caf41cacff70, type: 3}
-  defaultSprite: {fileID: 0}
-  dust: {fileID: 1562322629206622504}
 --- !u!60 &2580548336516971343
 PolygonCollider2D:
   m_ObjectHideFlags: 0
@@ -263,10 +281,5 @@ PrefabInstance:
 --- !u!4 &217914980374604844 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2529290311604123429, guid: 198590ab0e13ce4438633e9b8c5fe1fd, type: 3}
-  m_PrefabInstance: {fileID: 2314824533581159177}
-  m_PrefabAsset: {fileID: 0}
---- !u!198 &1562322629206622504 stripped
-ParticleSystem:
-  m_CorrespondingSourceObject: {fileID: 3869036837785606689, guid: 198590ab0e13ce4438633e9b8c5fe1fd, type: 3}
   m_PrefabInstance: {fileID: 2314824533581159177}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/Spells/Chair.prefab
+++ b/Assets/Prefabs/Spells/Chair.prefab
@@ -54,7 +54,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   attributes:
-    isHeavy: 0
+    isHeavy: 1
     isCopyable: 0
   defaultState: 0
 --- !u!114 &471494390818092482

--- a/Assets/Prefabs/Spells/Chair_Spell.prefab
+++ b/Assets/Prefabs/Spells/Chair_Spell.prefab
@@ -125,7 +125,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   attributes:
-    isHeavy: 0
+    isHeavy: 1
     isCopyable: 0
   defaultState: 0
 --- !u!114 &1715249207882019669

--- a/Assets/Prefabs/UI/UI_New.prefab
+++ b/Assets/Prefabs/UI/UI_New.prefab
@@ -25965,6 +25965,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 676689650680076178}
     m_Modifications:
+    - target: {fileID: 1843318393735327272, guid: a79ae8754c99815498c03638e88521dd, type: 3}
+      propertyPath: transition
+      value: 
+      objectReference: {fileID: 4968473044436410179}
     - target: {fileID: 2073974258979064554, guid: a79ae8754c99815498c03638e88521dd, type: 3}
       propertyPath: m_Name
       value: Collectible Manager

--- a/Assets/Scripts/BigGuyMelee.cs
+++ b/Assets/Scripts/BigGuyMelee.cs
@@ -30,7 +30,6 @@ public class BigGuyMelee : MonoBehaviour
 
     private void Update() {
         currTime += Time.deltaTime;
-        spell.CastSpell(fireDown);
         if (isWindBlasting) {
             Fire();
         }
@@ -49,50 +48,51 @@ public class BigGuyMelee : MonoBehaviour
     void Fire() {
         if (currTime >= 0) {
             //Instantiate(windBlast, this.gameObject.GetComponent<Transform>().position, Quaternion.identity);
-            switch(facingDir) {
+            Spell spellGO;
+            switch (facingDir) {
                 case BigGuyDirection.RIGHT:
-                    spell.CastSpell(fireDown);
                     AudioControl.Instance.PlaySFX(spell.spell.sfxString, PlayerController.Instance.gameObject, 0.1f, 0.5f);
-                    Instantiate(spell, this.gameObject.GetComponent<Transform>().position, Quaternion.identity);
-                    spell.CastSpell(fireRight);
+                    spellGO = Instantiate(spell, this.gameObject.GetComponent<Transform>().position, Quaternion.identity);
+                    spellGO.CastSpell(this, fireDown);
                     AudioControl.Instance.PlaySFX(spell.spell.sfxString, PlayerController.Instance.gameObject, 0.1f, 0.5f);
-                    Instantiate(spell, this.gameObject.GetComponent<Transform>().position, Quaternion.identity);
-                    spell.CastSpell(fireUp);
+                    spellGO = Instantiate(spell, this.gameObject.GetComponent<Transform>().position, Quaternion.identity);
+                    spellGO.CastSpell(this, fireRight);
                     AudioControl.Instance.PlaySFX(spell.spell.sfxString, PlayerController.Instance.gameObject, 0.1f, 0.5f);
-                    Instantiate(spell, this.gameObject.GetComponent<Transform>().position, Quaternion.identity);
+                    spellGO = Instantiate(spell, this.gameObject.GetComponent<Transform>().position, Quaternion.identity);
+                    spellGO.CastSpell(this, fireUp);
                     break;
                 case BigGuyDirection.LEFT:
-                    spell.CastSpell(fireDown);
                     AudioControl.Instance.PlaySFX(spell.spell.sfxString, PlayerController.Instance.gameObject, 0.1f, 0.5f);
-                    Instantiate(spell, this.gameObject.GetComponent<Transform>().position, Quaternion.identity);
-                    spell.CastSpell(fireLeft);
+                    spellGO = Instantiate(spell, this.gameObject.GetComponent<Transform>().position, Quaternion.identity);
+                    spellGO.CastSpell(this, fireDown);
                     AudioControl.Instance.PlaySFX(spell.spell.sfxString, PlayerController.Instance.gameObject, 0.1f, 0.5f);
-                    Instantiate(spell, this.gameObject.GetComponent<Transform>().position, Quaternion.identity);
-                    spell.CastSpell(fireUp);
+                    spellGO = Instantiate(spell, this.gameObject.GetComponent<Transform>().position, Quaternion.identity);
+                    spellGO.CastSpell(this, fireLeft);
                     AudioControl.Instance.PlaySFX(spell.spell.sfxString, PlayerController.Instance.gameObject, 0.1f, 0.5f);
-                    Instantiate(spell, this.gameObject.GetComponent<Transform>().position, Quaternion.identity);
+                    spellGO = Instantiate(spell, this.gameObject.GetComponent<Transform>().position, Quaternion.identity);
+                    spellGO.CastSpell(this, fireUp);
                     break;
                 case BigGuyDirection.UP:
-                    spell.CastSpell(fireUp);
                     AudioControl.Instance.PlaySFX(spell.spell.sfxString, PlayerController.Instance.gameObject, 0.1f, 0.5f);
-                    Instantiate(spell, this.gameObject.GetComponent<Transform>().position, Quaternion.identity);
-                    spell.CastSpell(fireLeft);
+                    spellGO = Instantiate(spell, this.gameObject.GetComponent<Transform>().position, Quaternion.identity);
+                    spellGO.CastSpell(this, fireUp);
                     AudioControl.Instance.PlaySFX(spell.spell.sfxString, PlayerController.Instance.gameObject, 0.1f, 0.5f);
-                    Instantiate(spell, this.gameObject.GetComponent<Transform>().position, Quaternion.identity);
-                    spell.CastSpell(fireRight);
+                    spellGO = Instantiate(spell, this.gameObject.GetComponent<Transform>().position, Quaternion.identity);
+                    spellGO.CastSpell(this, fireLeft);
                     AudioControl.Instance.PlaySFX(spell.spell.sfxString, PlayerController.Instance.gameObject, 0.1f, 0.5f);
-                    Instantiate(spell, this.gameObject.GetComponent<Transform>().position, Quaternion.identity);
+                    spellGO = Instantiate(spell, this.gameObject.GetComponent<Transform>().position, Quaternion.identity);
+                    spellGO.CastSpell(this, fireRight);
                     break;
                 case BigGuyDirection.DOWN:
-                    spell.CastSpell(fireDown);
                     AudioControl.Instance.PlaySFX(spell.spell.sfxString, PlayerController.Instance.gameObject, 0.1f, 0.5f);
-                    Instantiate(spell, this.gameObject.GetComponent<Transform>().position, Quaternion.identity);
-                    spell.CastSpell(fireLeft);
+                    spellGO = Instantiate(spell, this.gameObject.GetComponent<Transform>().position, Quaternion.identity);
+                    spellGO.CastSpell(this, fireDown);
                     AudioControl.Instance.PlaySFX(spell.spell.sfxString, PlayerController.Instance.gameObject, 0.1f, 0.5f);
-                    Instantiate(spell, this.gameObject.GetComponent<Transform>().position, Quaternion.identity);
-                    spell.CastSpell(fireRight);
+                    spellGO = Instantiate(spell, this.gameObject.GetComponent<Transform>().position, Quaternion.identity);
+                    spellGO.CastSpell(this, fireLeft);
                     AudioControl.Instance.PlaySFX(spell.spell.sfxString, PlayerController.Instance.gameObject, 0.1f, 0.5f);
-                    Instantiate(spell, this.gameObject.GetComponent<Transform>().position, Quaternion.identity);
+                    spellGO = Instantiate(spell, this.gameObject.GetComponent<Transform>().position, Quaternion.identity);
+                    spellGO.CastSpell(this, fireRight);
                     break;
             }
             currTime = -0.1f;

--- a/Assets/Scripts/FreezableModule.cs
+++ b/Assets/Scripts/FreezableModule.cs
@@ -11,11 +11,15 @@ public class FreezableModule : ObjectModule {
     [SerializeField] private float shineSpeed = 3.5f;
     [SerializeField] private Vector2 shineWaitRange = new Vector2(6, 8);
     [SerializeField] private Material freezeMaterial;
+    [SerializeField] private Sprite alternateSprite;
+    private Sprite defaultSprite;
 
     private float patternSeed;
 
     protected override void Awake() {
         base.Awake();
+        defaultSprite = spriteRenderer.sprite;
+        alternateSprite = alternateSprite ? alternateSprite : defaultSprite;
         patternSeed = Random.Range(1.5f, 10f);
         baseObject.OnHeatToggle += BaseObject_OnFireToggle;
     }
@@ -25,12 +29,14 @@ public class FreezableModule : ObjectModule {
             case ObjectState.Default:
                 if (!heatSignal) {
                     baseObject.SetState(ObjectState.Frozen);
+                    spriteRenderer.sprite = alternateSprite;
                     StopAllCoroutines();
                     StartCoroutine(FreezeAsync(1));
                 } break;
             case ObjectState.Frozen:
                 if (heatSignal) {
                     baseObject.SetState(ObjectState.Default);
+                    spriteRenderer.sprite = defaultSprite;
                     StopAllCoroutines();
                     StartCoroutine(FreezeAsync(0));
                 } break;
@@ -61,7 +67,7 @@ public class FreezableModule : ObjectModule {
                 mpb.SetFloat("_Shine_Pass", shinePass);
                 spriteRenderer.SetPropertyBlock(mpb);
                 yield return null;
-            } 
+            }
         }
     }
 }

--- a/Assets/Scripts/Spells/BaseSpellBehavior.cs
+++ b/Assets/Scripts/Spells/BaseSpellBehavior.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
 using UnityEngine;
 
 public abstract class BaseSpellBehavior : MonoBehaviour {

--- a/Assets/Scripts/Spells/FireballBehavior.cs
+++ b/Assets/Scripts/Spells/FireballBehavior.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using UnityEngine;
 
 public class FireballBehavior : BaseSpellBehavior {
@@ -66,6 +67,8 @@ public class FireballBehavior : BaseSpellBehavior {
     }
 
     private void OnTriggerEnter2D(Collider2D collision) {
+        if (spellScript.CasterColliders != null
+            && spellScript.CasterColliders.Contains(collision)) return;
         if (collision.TryGetComponent(out BaseObject baseObject)) {
             baseObject.Ignite(this);
         }

--- a/Assets/Scripts/Spells/IceballBehavior.cs
+++ b/Assets/Scripts/Spells/IceballBehavior.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using UnityEngine;
 
 public class IceballBehavior : BaseSpellBehavior {
@@ -71,6 +72,8 @@ public class IceballBehavior : BaseSpellBehavior {
     }
 
 	private void OnTriggerEnter2D(Collider2D collision) {
+		if (spellScript.CasterColliders != null
+			&& spellScript.CasterColliders.Contains(collision)) return;
 		if (collision.TryGetComponent(out BaseObject baseObject)) {
 			baseObject.Freeze(this);
 		}

--- a/Assets/Scripts/Spells/Spell.cs
+++ b/Assets/Scripts/Spells/Spell.cs
@@ -1,10 +1,10 @@
-using System;
+using System.Linq;
 using UnityEngine;
 
 public class Spell : MonoBehaviour
 {
     public SpellSO spell;
-    public event Action<GameObject> OnSpellDestroy;
+    public event System.Action<GameObject> OnSpellDestroy;
 
     //[SerializeField] private LogicScript logicScript;
     [SerializeField] private Collider2D bruhCollider;
@@ -17,15 +17,13 @@ public class Spell : MonoBehaviour
     [SerializeField] private bool isPiplup = false;
 
     public Vector2 direction;
+    public Collider2D[] CasterColliders { get; private set; }
 
     public int damage;
 
 
     private void Awake()
     {
-        if (!isChair || !isPiplup) {
-            transform.Rotate(rotate);
-        }
 
         if (bruhCollider == null) bruhCollider = GetComponent<Collider2D>();
         bruhCollider.isTrigger = true;
@@ -54,7 +52,7 @@ public class Spell : MonoBehaviour
         transform.Translate(Vector3.up * spell.speed * Time.deltaTime);
     }
 
-    public virtual void CastSpell(Vector2 dir) {
+    public virtual void CastSpell(MonoBehaviour caster, Vector2 dir) {
         direction = dir;
         if(dir.x < 0)
             rotate = new Vector3(0, 0, 90);
@@ -64,7 +62,8 @@ public class Spell : MonoBehaviour
             rotate = new Vector3(0, 0, 0);
         if (dir.y < 0)
             rotate = new Vector3(0, 0, 180);
-
+        if (!isChair || !isPiplup) transform.Rotate(rotate);
+        CasterColliders = caster.GetComponentsInChildren<Collider2D>(true);
         spellActive = true;
     }
 
@@ -72,8 +71,9 @@ public class Spell : MonoBehaviour
     /// OnTriggerEnter is called when the Collider other enters the trigger.
     /// </summary>
     /// <param name="other">The other Collider involved in this collision.</param>
-    private void OnTriggerEnter2D(Collider2D other)
-    {
+    private void OnTriggerEnter2D(Collider2D other) {
+        if (CasterColliders != null 
+            && CasterColliders.Contains(other)) return;
         IDamageable damageable = other.GetComponent<IDamageable>();
         if (damageable != null) {
             // print("spellscript");

--- a/Assets/Scripts/Spells/SpellCastManager.cs
+++ b/Assets/Scripts/Spells/SpellCastManager.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using System;
 
-public class SpellCastManager : MonoBehaviour
-{
+public class SpellCastManager : MonoBehaviour {
     //Responsible for spawning spells
 
     [SerializeField] private float startLagTime;
@@ -45,18 +44,18 @@ public class SpellCastManager : MonoBehaviour
         }
         Vector2 face = new Vector2(PlayerController.Instance.FacingDir.x, PlayerController.Instance.FacingDir.y);
         Spell spell = spellDict[e.spellType];
-        
-        spell.CastSpell(face);
+
         PlayerController.Instance.animator.SetTrigger("doSpellCast");
         PlayerController.Instance.DeactivateMovement();
-        StartCoroutine(CastSpell(spell));
+        StartCoroutine(CastSpell(spell, face));
     }
 
-    IEnumerator CastSpell(Spell spell) {
+    IEnumerator CastSpell(Spell spell, Vector2 face) {
 		AudioControl.Instance.PlaySFX(spell.spell.sfxString, PlayerController.Instance.gameObject, 0.1f, 0.5f);
 		yield return new WaitForSeconds(startLagTime);
         TriggerParticles(spell);
-        Instantiate(spell, PlayerController.Instance.castPoint.position, Quaternion.identity);
+        Spell spellGO = Instantiate(spell, PlayerController.Instance.castPoint.position, Quaternion.identity);
+        spellGO.CastSpell(PlayerController.Instance, face);
         PlayerController.Instance.ActivateMovement();
 	}
 

--- a/Assets/Scripts/Spells/WindblastBehavior.cs
+++ b/Assets/Scripts/Spells/WindblastBehavior.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using UnityEngine;
 
 public class WindblastBehavior : BaseSpellBehavior {
@@ -40,10 +41,13 @@ public class WindblastBehavior : BaseSpellBehavior {
 	}
 
 	private void OnTriggerEnter2D(Collider2D collision) {
+		if (spellScript.CasterColliders != null 
+			&& spellScript.CasterColliders.Contains(collision)) return;
 		if (collision.TryGetComponent(out BaseObject baseObject)) {
 			baseObject.Blow(this, spellScript.direction, pushStrength);
 			if (baseObject.Attributes.isHeavy) state = State.End;
 		} else if (collision.TryGetComponent(out IPushable pushable)) {
+			Debug.Log($"{this}\n{spellScript.CasterColliders}");
 			pushable.Push(spellScript.direction, pushStrength, pushStrength);
 			state = State.End;
 		}

--- a/Assets/Scripts/UI/CollectibleController.cs
+++ b/Assets/Scripts/UI/CollectibleController.cs
@@ -21,7 +21,8 @@ public class CollectibleController : MonoBehaviour {
 	/// <br></br> Listeners: All Collectible Managers, Notification Manager, PauseMenu; </summary>
 	public event System.Action OnCallsEnd;
 
-	public TransitionManager Transition { get; private set; }
+	[SerializeField] private TransitionManager transition;
+	public TransitionManager Transition => transition;
 	private readonly Queue<ItemData> callQueue = new();
 
 	/// <summary> Whether a collectible interaction is currently being displayed; </summary>
@@ -30,7 +31,6 @@ public class CollectibleController : MonoBehaviour {
 	public bool InSequence { get; private set; }
 
 	void Awake() {
-		Transition = FindObjectOfType<TransitionManager>(true);
 		foreach (CollectibleManager cm in GetComponentsInChildren<CollectibleManager>(true)) { cm.Init(this); };
 		GetComponentInChildren<NotificationManager>(true).Init(this);
 	}
@@ -61,7 +61,7 @@ public class CollectibleController : MonoBehaviour {
 		}
     }
 
-	public bool CheckClaimedStatus(ItemData itemData) {
+    public bool CheckClaimedStatus(ItemData itemData) {
 		ItemCall call = new(itemData);
 		OnInventoryRequest?.Invoke(this, call);
 		return call.output.Contains(itemData);

--- a/Assets/Scripts/UI/Lab Report UI/ReportManager.cs
+++ b/Assets/Scripts/UI/Lab Report UI/ReportManager.cs
@@ -146,6 +146,7 @@ public class ReportManager : CollectibleManager<ReportData> {
 					alpha = MoveOpacity(0, fadeRate * 1.75f);
 					if (alpha == 0) {
 						if (FetchString()) {
+							SetOpacity(1, currentNote.alpha);
 							NextPage();
 							currentIndex = 0;
 							writeTimer = 0.5f;

--- a/Assets/Scripts/Unused/Fan.cs
+++ b/Assets/Scripts/Unused/Fan.cs
@@ -13,7 +13,7 @@ public class Fan : BaseObject {
 
     private const string SPIN_CONDITION = "IsSpinning";
 
-    public bool IsRotating => animator.GetBool(SPIN_CONDITION);
+    public bool IsRotating => gameObject.activeSelf ? animator.GetBool(SPIN_CONDITION) : false;
 
     protected override void Awake() {
         base.Awake();

--- a/Assets/Timeline/IntroTimeline.playable
+++ b/Assets/Timeline/IntroTimeline.playable
@@ -41,6 +41,24 @@ MonoBehaviour:
     m_Objects:
     - {fileID: 2584238433344379297}
     - {fileID: 8669058322060240132}
+    - {fileID: -6712190808605417882}
+    - {fileID: 669410035384797385}
+--- !u!114 &-6712190808605417882
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 15c38f6fa1940124db1ab7f6fe7268d1, type: 3}
+  m_Name: Signal Emitter
+  m_EditorClassIdentifier: 
+  m_Time: 0
+  m_Retroactive: 0
+  m_EmitOnce: 1
+  m_Asset: {fileID: 11400000, guid: 8de9396e1a2bb3e408efd0e6cbeffb4d, type: 2}
 --- !u!114 &-6321455803727181187
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -78,6 +96,22 @@ MonoBehaviour:
     m_ScenePreview: 1
   m_DurationMode: 0
   m_MarkerTrack: {fileID: -7897617096019260251}
+--- !u!114 &669410035384797385
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 15c38f6fa1940124db1ab7f6fe7268d1, type: 3}
+  m_Name: Signal Emitter
+  m_EditorClassIdentifier: 
+  m_Time: 2.5833333333333335
+  m_Retroactive: 0
+  m_EmitOnce: 1
+  m_Asset: {fileID: 11400000, guid: 1fd51d4707a3c0a42b292e42691d1f83, type: 2}
 --- !u!114 &2584238433344379297
 MonoBehaviour:
   m_ObjectHideFlags: 1


### PR DESCRIPTION
Changelog:
- Fixed Camera Priority after intro timeline;
- Casted spells now ignore the caster, effectively fixing the player being pushed by its own windblast;
- Mirrors and chairs now stop windblasts;
- Reintroduced Joseph's sprites in tandem with Chris' shader;
- Scientist is now freezable;
- Fixed warnings from trying to pull data from disabled fan animators
- Fixed issue where two spells cast at the same time would share a direction despite one of them being cast another way (we were modifying the prefab asset instead of the new instance);
- Fixed the lab report not showing pages past the first;
- Fixed the camera not following the player in the Credits Scene;
- Removed the FindObjectOfType<>() call from the Collectible Controller;