### PR TITLE
Fix Movement Issues + Related Bugs

### DIFF
--- a/Assets/Prefabs/Player/AC_Player.controller
+++ b/Assets/Prefabs/Player/AC_Player.controller
@@ -277,37 +277,37 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Y
     m_Type: 1
     m_DefaultFloat: 1
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isWalking
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: doMelee
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: doSpellCast
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isHurt
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer

--- a/Assets/Prefabs/Player/Animations/player_melee_down.anim
+++ b/Assets/Prefabs/Player/Animations/player_melee_down.anim
@@ -262,14 +262,14 @@ AnimationClip:
   m_HasMotionFloatCurves: 0
   m_Events:
   - time: 0
-    functionName: DeactivateMovement
+    functionName: SafeDeactivateMovement
     data: 
     objectReferenceParameter: {fileID: 0}
     floatParameter: 0
     intParameter: 0
     messageOptions: 0
   - time: 0.41666666
-    functionName: ActivateMovement
+    functionName: SafeActivateMovement
     data: 
     objectReferenceParameter: {fileID: 0}
     floatParameter: 0

--- a/Assets/Prefabs/Player/Animations/player_melee_left.anim
+++ b/Assets/Prefabs/Player/Animations/player_melee_left.anim
@@ -283,14 +283,14 @@ AnimationClip:
   m_HasMotionFloatCurves: 0
   m_Events:
   - time: 0
-    functionName: DeactivateMovement
+    functionName: SafeDeactivateMovement
     data: 
     objectReferenceParameter: {fileID: 0}
     floatParameter: 0
     intParameter: 0
     messageOptions: 0
   - time: 0.6666667
-    functionName: ActivateMovement
+    functionName: SafeActivateMovement
     data: 
     objectReferenceParameter: {fileID: 0}
     floatParameter: 0

--- a/Assets/Prefabs/Player/Animations/player_melee_right.anim
+++ b/Assets/Prefabs/Player/Animations/player_melee_right.anim
@@ -286,14 +286,14 @@ AnimationClip:
   m_HasMotionFloatCurves: 0
   m_Events:
   - time: 0
-    functionName: DeactivateMovement
+    functionName: SafeDeactivateMovement
     data: 
     objectReferenceParameter: {fileID: 0}
     floatParameter: 0
     intParameter: 0
     messageOptions: 0
   - time: 0.6666667
-    functionName: ActivateMovement
+    functionName: SafeActivateMovement
     data: 
     objectReferenceParameter: {fileID: 0}
     floatParameter: 0

--- a/Assets/Prefabs/Player/Animations/player_melee_up.anim
+++ b/Assets/Prefabs/Player/Animations/player_melee_up.anim
@@ -286,14 +286,14 @@ AnimationClip:
   m_HasMotionFloatCurves: 0
   m_Events:
   - time: 0
-    functionName: DeactivateMovement
+    functionName: SafeDeactivateMovement
     data: 
     objectReferenceParameter: {fileID: 0}
     floatParameter: 0
     intParameter: 0
     messageOptions: 0
   - time: 0.6666667
-    functionName: ActivateMovement
+    functionName: SafeActivateMovement
     data: 
     objectReferenceParameter: {fileID: 0}
     floatParameter: 0

--- a/Assets/Scenes/Joseph Seo/IntroSkipLogic.cs
+++ b/Assets/Scenes/Joseph Seo/IntroSkipLogic.cs
@@ -2,32 +2,56 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using TMPro;
 
 public class IntroSkipLogic : MonoBehaviour
 {
 
     [SerializeField] private TransitionManager transitionManager;
     [SerializeField] private GameObject skipText;
-    bool AtConfirmationToSkip = false;
+    private TextMeshProUGUI text;
+    private bool AtConfirmationToSkip = false;
 
+    private void Start()
+    {
+        text = skipText.GetComponentInChildren<TextMeshProUGUI>();
+    }
     void Update() {
-        if (Input.GetKeyDown(KeyCode.Space) && SceneManager.GetActiveScene().buildIndex == 3) {
-            SkipIntro();
-		} else if (AtConfirmationToSkip && Input.anyKeyDown) {
-            skipText.SetActive(false);
-			AtConfirmationToSkip = false;
-		}
+        if (!AtConfirmationToSkip && Input.anyKeyDown) {
+            StartCoroutine(ToggleText(true));
+        } else {
+            if (Input.GetKeyDown(KeyCode.Space) && SceneManager.GetActiveScene().buildIndex == 3) {
+                SkipIntro();
+            } else if (Input.anyKeyDown) {
+                StartCoroutine(ToggleText(false));
+            }
+        }
     }
 
     private void SkipIntro() {
-        if (!AtConfirmationToSkip) {
-            AtConfirmationToSkip = true;
+        skipText.SetActive(false);
+        transitionManager.SetTransitionColor(Color.black);
+		transitionManager.FadeOut();
+		transitionManager.LoadLevel();
+    }
+
+    private IEnumerator ToggleText(bool status) {
+        if (status) {
             skipText.SetActive(true);
-        } else if (AtConfirmationToSkip) {
+            AtConfirmationToSkip = true;
+            text.alpha = 0;
+            while (text.alpha < 1) {
+                text.alpha += .1f;
+                yield return new WaitForSeconds(.01f);
+            }
+        } else {
+            AtConfirmationToSkip = false;
+            text.alpha = 1;
+            while (text.alpha > 0) {
+                text.alpha -= .1f;
+                yield return new WaitForSeconds(.01f);
+            }
             skipText.SetActive(false);
-            transitionManager.SetTransitionColor(Color.black);
-			transitionManager.FadeOut();
-			transitionManager.LoadLevel();
         }
     }
 

--- a/Assets/Scripts/Spells/SpellCastManager.cs
+++ b/Assets/Scripts/Spells/SpellCastManager.cs
@@ -46,7 +46,7 @@ public class SpellCastManager : MonoBehaviour {
         Spell spell = spellDict[e.spellType];
 
         PlayerController.Instance.animator.SetTrigger("doSpellCast");
-        PlayerController.Instance.DeactivateMovement();
+        PlayerController.Instance.SafeDeactivateMovement();
         StartCoroutine(CastSpell(spell, face));
     }
 
@@ -56,7 +56,7 @@ public class SpellCastManager : MonoBehaviour {
         TriggerParticles(spell);
         Spell spellGO = Instantiate(spell, PlayerController.Instance.castPoint.position, Quaternion.identity);
         spellGO.CastSpell(PlayerController.Instance, face);
-        PlayerController.Instance.ActivateMovement();
+        PlayerController.Instance.SafeActivateMovement();
 	}
 
     public void TriggerParticles(Spell s) {

--- a/Assets/Scripts/UI/PauseMenu.cs
+++ b/Assets/Scripts/UI/PauseMenu.cs
@@ -88,7 +88,7 @@ public class PauseMenu : MonoBehaviour {
             notebook.SetActive(true);
         } ToggleActiveMenu(false);
         pauseMenuUI.SetActive(false);
-		PlayerController.Instance.ActivateMovement();
+		PlayerController.Instance.SafeActivateMovement();
 		Time.timeScale = 1f;
         transition.DarkenIn(true);
         GameIsPaused = false;
@@ -100,7 +100,7 @@ public class PauseMenu : MonoBehaviour {
         notebook.SetActive(false);
         ToggleActiveMenu(true);
         pauseMenuUI.SetActive(true);
-		PlayerController.Instance.DeactivateMovement();
+		PlayerController.Instance.SafeDeactivateMovement();
         Time.timeScale = 0f;
         transition.DarkenOut(true);
         GameIsPaused = true;


### PR DESCRIPTION
-Fix most of the movement related bugs related to moving after casting a spell while you shouldn't be able to 
-Fix being able to be damaged during a Camera Transition (You can't move, you shouldn't be able to be damaged) 
-Fixed niche movement glitch after dying where holding a key wouldn't let you move until you released and moved again 
-Project Settings changes are changing the Unity Animator stuff for melee because that's how the previous guy called ActivateMovement and DeactivateMovement. They've been switched to their safe variants.
-(NOT FIXED) Picking up things during a camera transition can result in you being able to move around during it. 
